### PR TITLE
Added a comment to ch01-01 project setup

### DIFF
--- a/tutorials-book/src/ch01-01-project-setup.md
+++ b/tutorials-book/src/ch01-01-project-setup.md
@@ -55,7 +55,9 @@ use sea_orm::{Database, DbErr};
 
 // Change this according to your database implementation,
 // or supply it as an environment variable.
-const DATABASE_URL: &str = "mysql://root:root@localhost:3306";
+// the database URL string follows the following format:
+// "protocol://username:password@host:port/database"
+const DATABASE_URL: &str = "mysql://root:password@localhost:3306";
 
 async fn run() -> Result<(), DbErr> {
     let db = Database::connect(DATABASE_URL).await?;


### PR DESCRIPTION
Added a comment to clarify the format of the database connection string. 

This will help others who follow this tutorial to know where to put the password for their DB, as it wasn't very clear, and I had to search elsewhere (seaORM docs https://www.sea-ql.org/SeaORM/docs/install-and-config/connection/), which is outside of this tutorial book.


