### PR TITLE
Added missing 'use'-statements

### DIFF
--- a/tutorials-book/src/ch01-05-basic-crud-operations.md
+++ b/tutorials-book/src/ch01-05-basic-crud-operations.md
@@ -10,6 +10,9 @@ The entities are the Rust representation of the tables in the database. SeaORM e
 // src/main.rs
 
 + mod entities;
++ use entities::{bakery, chef};
++ use entities::bakery::Entity as Bakery;
++ use entities::chef::Entity as Chef;
 
 ...
 


### PR DESCRIPTION
## PR Info

Code is easier to comprehend with the missing use-statements (especially because of the necessatiy to use 'as').
